### PR TITLE
Fix % stats display on Items pages

### DIFF
--- a/pages/itemArmor.html
+++ b/pages/itemArmor.html
@@ -166,7 +166,7 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td><span ng-repeat="(statName, statVal) in item.bonusStat">{{statName | changeStat}}: ~{{(statVal[0]+statVal[1])/2 | number:0}} </span></td>
+		<td><span ng-repeat="(statName, statVal) in item.bonusStat">{{statName | changeStat}}: ~{{(statVal[0]+statVal[1])/2 | fixPercentStat : statName | number:0}} </span></td>
 		<td class="center">Lv. {{item.itemLevel}}</td>
 	</tr>	
   </tbody>

--- a/pages/itemTrinket.html
+++ b/pages/itemTrinket.html
@@ -32,7 +32,7 @@
 		<td class="center">Lv. {{item.itemLevel}}</td>
     </tr>
 	<tr>
-		<td><span ng-repeat="(statName, statVal) in item.bonusStat">{{statName | changeStat}}: ~{{(statVal[0]+statVal[1])/2 | number:0}} </span></td>
+		<td><span ng-repeat="(statName, statVal) in item.bonusStat">{{statName | changeStat}}: ~{{(statVal[0]+statVal[1])/2 | fixPercentStat : statName | number:0}} </span></td>
 		<td class="center"></td>
 	</tr>
   </tbody>

--- a/pages/itemWeapon.html
+++ b/pages/itemWeapon.html
@@ -184,7 +184,7 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td><span ng-repeat="(statName, statVal) in item.bonusStat">{{statName | changeStat}}: ~{{(statVal[0]+statVal[1])/2 | number:0}} </span></td>
+		<td><span ng-repeat="(statName, statVal) in item.bonusStat">{{statName | changeStat}}: ~{{(statVal[0]+statVal[1])/2 | fixPercentStat : statName | number:0}} </span></td>
 		<td class="center">Lv. {{item.itemLevel}}</td>
 	</tr>
   </tbody>


### PR DESCRIPTION
This fix is simular to fix from pull request #20 . Seems like for now stat displaying are same across the site