### PR TITLE
Quest reward 2 count display fixed

### DIFF
--- a/pages/quests.html
+++ b/pages/quests.html
@@ -130,7 +130,7 @@
 			<td>2.</td>
 			<td class="center"><img ng-src="assets/{{mats[quest.reward2[0]-1].image}}"></td>
 			<td><a class="quality-{{mats[quest.reward2[0]-1].rarity}}" href="#!/items/material/{{mats[quest.reward2[0]-1].name}}">{{mats[quest.reward2[0]-1].name}}</a></td>
-			<td>{{quest.reward2[1]}}<span ng-if="quest.reward2[2] > 1"> - {{quest.reward2[2]}}</span></td>
+			<td>{{quest.reward2[1]*0.8 | number:0}}<span ng-if="quest.reward2[2] > 1"> - {{quest.reward2[2]*1.3 | number:0}}</span></td>
 			<td>100%</td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
After [this commit](https://github.com/Dave-Hughes/MerchantGameDB/commit/e1cc433b128ffc2ec613be5520a5e5bfb50f9edd#diff-f04cd7e339a9eac7f27acb1bfcadeee8) there are different numbers on materials.html and quests.html. From my game experience formula from materials.html is right one. Please correct me if I'm wrong